### PR TITLE
Moved over realtime connection information to riak_core_metadata

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -49,6 +49,9 @@
 -define(BT_META_BUCKET_NAME, bucket_name).
 -define(BT_META_BLACKLIST, realtime_blacklist).
 
+-define(RIAK_REPL2_RTQ_CONFIG_KEY, {riak_repl2_rtq, config}).
+-define(RTSOURCE_REALTIME_CONNECTIONS_KEY, {riak_repl2_rtsource, realtime_connections}).
+
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).
 -type(repl_addr() :: {ip_addr_str(), ip_portnum()}).

--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -807,7 +807,7 @@ shuffle(List) ->
 get_my_remote_ip_list(_Remote, [], _Return) ->
     {ok, []};
 get_my_remote_ip_list(Remote, RemoteUnsorted, Return) ->
-    case riak_repl2_rtsource_conn_data_mgr:read(active_nodes) of
+    case riak_repl_util:read_realtime_active_nodes() of
         no_leader ->
             {ok, []};
         %% SourceNodes = [SourceNode1, SourceNode3, SourceNode2 ...]
@@ -871,7 +871,7 @@ build_primary_dict([{Key, Value}| Rest], Dict) ->
 %% sink nodes to an index which would cause active connections to be dropped and made by other nodes.
 %% Output: dict -> Key-Value: {Index, SinkNode}
 link_addrs(AllPrimariesDict, SinkNodes, Remote) ->
-    case riak_repl2_rtsource_conn_data_mgr:read(realtime_connections, Remote) of
+    case riak_repl_util:read_realtime_endpoints(Remote) of
         no_leader ->
             no_leader;
         %% ActiveConnsDict: this is a dictionary of active realtime connections

--- a/src/riak_repl2_rtsource_conn_sup.erl
+++ b/src/riak_repl2_rtsource_conn_sup.erl
@@ -6,7 +6,10 @@
     start_link/0,
     enable/1,
     disable/1,
-    enabled/0
+    enabled/0,
+
+    set_leader/2,
+    node_watcher_update/1
 ]).
 
 -export([init/1]).
@@ -26,11 +29,23 @@ disable(Remote) ->
     lager:info("Stopping replication realtime source ~p", [Remote]),
     _ = supervisor:terminate_child(?MODULE, Remote),
     _ = supervisor:delete_child(?MODULE, Remote),
-    riak_repl2_rtsource_conn_data_mgr:delete(realtime_connections, Remote).
+    riak_repl_util:delete_realtime_endpoints(Remote).
 
 enabled() ->
-    [ {Remote, ConnMgrPid} || {Remote, ConnMgrPid, _, [riak_repl2_rtsource_conn_mgr]}
+    [{Remote, ConnMgrPid} || {Remote, ConnMgrPid, _, [riak_repl2_rtsource_conn_mgr]}
         <- supervisor:which_children(?MODULE), is_pid(ConnMgrPid)].
+
+set_leader(LeaderNode, _LeaderPid) ->
+    lists:foreach(
+        fun({_, Pid, _, [riak_repl2_rtsource_conn_mgr]}) ->
+            riak_repl2_rtsource_conn_mgr:set_leader(Pid, LeaderNode)
+        end, supervisor:which_children(?MODULE)).
+
+node_watcher_update(_Services) ->
+    lists:foreach(
+        fun({_, Pid, _, [riak_repl2_rtsource_conn_mgr]}) ->
+            riak_repl2_rtsource_conn_mgr:node_watcher_update(Pid)
+        end, supervisor:which_children(?MODULE)).
 
 %% @private
 init([]) ->
@@ -38,6 +53,7 @@ init([]) ->
     %% once connmgr is started by core.  Must be started/registered
     %% before sources are started.
     riak_repl2_rt:register_remote_locator(),
+    riak_core_node_watcher_events:add_sup_callback(fun ?MODULE:node_watcher_update/1),
 
     {ok, Ring} = riak_core_ring_manager:get_raw_ring(),
     Remotes = riak_repl_ring:rt_started(Ring),

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -63,7 +63,7 @@ start(_Type, _StartArgs) ->
 
     riak_core_capability:register(
         {riak_repl, realtime_connections},
-        [v1, legacy],
+        [v2, v1, legacy],
         legacy
         ),
     riak_core_capability:register(
@@ -108,10 +108,12 @@ start(_Type, _StartArgs) ->
             riak_repl2_leader:register_notify_fun(
               fun riak_core_cluster_mgr:set_leader/2),
 
+            % TODO: remove in the next release (data_mgr will no longer be used in v2 realtime_connections)
+            riak_repl2_leader:register_notify_fun(
+                fun riak_repl2_rtsource_conn_data_mgr:set_leader/2),
             % rtsource supverisors -> rtsource_conn_mgr will follow the leader
             riak_repl2_leader:register_notify_fun(
-                fun riak_repl2_rtsource_conn_data_mgr:set_leader/2
-            ),
+                fun riak_repl2_rtsource_conn_sup:set_leader/2),
 
             %% fullsync co-ordincation will follow leader
             riak_repl2_leader:register_notify_fun(


### PR DESCRIPTION
This work moves away from the use of riak_repl2_rtsource_conn_data_mgr which utilises the riak_core_ring to store data regarding realtime connections made from the source cluster.

This removes a race condition that causes realtime enable/start to be reverted due to ring's reconciling to older version of the ring.